### PR TITLE
feat: replace pdm to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
           cache: 'pip'
           cache-dependency-path: |
             **/pyproject.toml
-            **/pdm.lock
+            **/uv.lock
       - name: Install dependencies
-        run: python -m pip install --upgrade nox pdm
+        run: python -m pip install --upgrade nox uv
       - name: Run linters
         run: nox -vs lint
   check_crufted_project:
@@ -46,6 +46,6 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: 'pip'
       - name: Install dependencies
-        run: python -m pip install --upgrade nox pdm
+        run: python -m pip install --upgrade nox uv
       - name: Run checks on project created from template
         run: nox -vt crufted_project

--- a/.gitignore
+++ b/.gitignore
@@ -101,15 +101,7 @@ ipython_config.py
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
 
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/#use-with-ide
-.pdm.toml
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 
 # Celery stuff

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -61,7 +61,21 @@ def main():
             filepath.unlink()
 
     with working_directory(PROJECT_ROOT):
-        subprocess.check_call(["pdm", "lock", "--update-reuse", "--group", ":all"])
+        # Initialize git repository if not already present (required for hatch-vcs)
+        if not (PROJECT_ROOT / ".git").exists():
+            try:
+                subprocess.check_call(["git", "init"])
+                subprocess.check_call(["git", "add", "."])
+                subprocess.check_call(["git", "commit", "-m", "Initial commit"])
+            except subprocess.CalledProcessError as e:
+                print(f"Warning: Failed to initialize git repository: {e}")
+
+        try:
+            subprocess.check_call(["uv", "sync"])
+            subprocess.check_call(["uv", "lock", "--upgrade"])
+        except subprocess.CalledProcessError as e:
+            print(f"Warning: Failed to lock dependencies: {e}")
+            print("You may need to run 'uv lock --upgrade' manually after setting up the git repository.")
 
 
 if __name__ == "__main__":

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -61,21 +61,8 @@ def main():
             filepath.unlink()
 
     with working_directory(PROJECT_ROOT):
-        # Initialize git repository if not already present (required for hatch-vcs)
-        if not (PROJECT_ROOT / ".git").exists():
-            try:
-                subprocess.check_call(["git", "init"])
-                subprocess.check_call(["git", "add", "."])
-                subprocess.check_call(["git", "commit", "-m", "Initial commit"])
-            except subprocess.CalledProcessError as e:
-                print(f"Warning: Failed to initialize git repository: {e}")
-
-        try:
-            subprocess.check_call(["uv", "sync"])
-            subprocess.check_call(["uv", "lock", "--upgrade"])
-        except subprocess.CalledProcessError as e:
-            print(f"Warning: Failed to lock dependencies: {e}")
-            print("You may need to run 'uv lock --upgrade' manually after setting up the git repository.")
+        subprocess.check_call(["uv", "sync"])
+        subprocess.check_call(["uv", "lock", "--upgrade"])
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ ignore = [
 "test/**" = ["D", "F403", "F405"]
 
 [tool.codespell]
-skip = "*.min.js,pdm.lock"
+skip = "*.min.js,uv.lock"
 ignore-words-list = "datas"
 
 [tool.towncrier]

--- a/{{cookiecutter.package_name}}/# COOKIECUTTER{% if cookiecutter.build_docker_image == "y" %}.dockerignore# COOKIECUTTER{% endif %}
+++ b/{{cookiecutter.package_name}}/# COOKIECUTTER{% if cookiecutter.build_docker_image == "y" %}.dockerignore# COOKIECUTTER{% endif %}
@@ -1,4 +1,4 @@
-.git
+# .git -- git is required for hatch-vcs
 *.pyc
 *.sqlite3
 *~

--- a/{{cookiecutter.package_name}}/# COOKIECUTTER{% if cookiecutter.build_docker_image == "y" %}.dockerignore# COOKIECUTTER{% endif %}
+++ b/{{cookiecutter.package_name}}/# COOKIECUTTER{% if cookiecutter.build_docker_image == "y" %}.dockerignore# COOKIECUTTER{% endif %}
@@ -10,7 +10,6 @@ venv
 media/
 .backups/
 .envrc
-.pdm-python
 .terraform.lock.hcl
 .terraform/
 .nox/

--- a/{{cookiecutter.package_name}}/# COOKIECUTTER{% if cookiecutter.build_docker_image == "y" %}Dockerfile# COOKIECUTTER{% endif %}
+++ b/{{cookiecutter.package_name}}/# COOKIECUTTER{% if cookiecutter.build_docker_image == "y" %}Dockerfile# COOKIECUTTER{% endif %}
@@ -8,7 +8,8 @@ RUN apk add --no-cache \
     gcc \
     musl-dev \
     libffi-dev \
-    openssl-dev
+    openssl-dev \
+    git
 
 RUN pip install --no-cache-dir uv
 
@@ -21,7 +22,11 @@ RUN uv export --format requirements-txt > /tmp/requirements.txt
 RUN uv build --wheel --out-dir /tmp/wheelhouse
 
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
-RUN pip install --no-cache-dir /tmp/wheelhouse/*.whl
+RUN pip install --no-cache-dir --no-deps /tmp/wheelhouse/*.whl
+
+# Remove the local package reference (lines starting with .) from requirements.txt
+# Install only the external dependencies from the cleaned requirements.txt
+RUN sed '/^\./d' /tmp/requirements.txt > /tmp/requirements-clean.txt && pip install --no-cache-dir -r /tmp/requirements-clean.txt
 
 FROM python:${PYTHON_VERSION}-alpine
 

--- a/{{cookiecutter.package_name}}/# COOKIECUTTER{% if cookiecutter.build_docker_image == "y" %}Dockerfile# COOKIECUTTER{% endif %}
+++ b/{{cookiecutter.package_name}}/# COOKIECUTTER{% if cookiecutter.build_docker_image == "y" %}Dockerfile# COOKIECUTTER{% endif %}
@@ -10,18 +10,15 @@ RUN apk add --no-cache \
     libffi-dev \
     openssl-dev
 
-ENV PDM_VERSION=2.18.1
-RUN curl -sSL https://raw.githubusercontent.com/pdm-project/pdm/main/install-pdm.py | python3 -
+RUN pip install --no-cache-dir uv
 
 ENV PATH="/root/.local/bin:$PATH"
 
 COPY . .
 
-ENV PDM_CHECK_UPDATE=false
-RUN pdm export > /tmp/requirements.txt
+RUN uv export --format requirements-txt > /tmp/requirements.txt
 
-ARG PDM_BUILD_SCM_VERSION="0.0.1"
-RUN pdm build -d /tmp/wheelhouse
+RUN uv build --wheel --out-dir /tmp/wheelhouse
 
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 RUN pip install --no-cache-dir /tmp/wheelhouse/*.whl

--- a/{{cookiecutter.package_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/ci.yml
@@ -22,15 +22,15 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
-          cache-dependency-path: 'pdm.lock'
+          cache-dependency-path: 'uv.lock'
       - uses: actions/cache@v4
         with:
-          path: ~/.cache/pdm
-          key: ${{ env.PYTHON_DEFAULT_VERSION }}-pdm-${{ hashFiles('pdm.lock') }}
-          restore-keys: ${{ env.PYTHON_DEFAULT_VERSION }}-pdm-
+          path: ~/.cache/uv
+          key: ${{ env.PYTHON_DEFAULT_VERSION }}-uv-${{ hashFiles('uv.lock') }}
+          restore-keys: ${{ env.PYTHON_DEFAULT_VERSION }}-uv-
 # COOKIECUTTER{%- endraw %}
       - name: Install dependencies
-        run: python -m pip install --upgrade nox 'pdm>=2.12,<3'
+        run: python -m pip install --upgrade nox uv
       - name: Run linters
         run: nox -vs lint
   test:
@@ -56,14 +56,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: 'pdm.lock'
+          cache-dependency-path: 'uv.lock'
       - uses: actions/cache@v4
         with:
-          path: ~/.cache/pdm
-          key: ${{ matrix.python-version }}-pdm-${{ hashFiles('pdm.lock') }}
-          restore-keys: ${{ matrix.python-version }}-pdm-
+          path: ~/.cache/uv
+          key: ${{ matrix.python-version }}-uv-${{ hashFiles('uv.lock') }}
+          restore-keys: ${{ matrix.python-version }}-uv-
       - name: Install dependencies
-        run: python -m pip install --upgrade 'nox==2024.3.2' 'pdm==2.13.2'
+        run: python -m pip install --upgrade 'nox==2024.3.2' uv
       - name: Run unit tests
         run: nox -vs test
 # COOKIECUTTER{%- endraw %}

--- a/{{cookiecutter.package_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
 
       - name: Install dependencies
-        run: python -m pip install --upgrade nox 'pdm>=2.12,<3'
+        run: python -m pip install --upgrade nox uv
 
       - name: Read the Changelog
         id: read-changelog
@@ -85,7 +85,7 @@ jobs:
         continue-on-error: ${{ fromJSON(needs.get-version.outputs.draft) }}
 
       - name: Build
-        run: pdm build
+        run: uv build
 
       - name: Sign distribution
         uses: sigstore/gh-action-sigstore-python@v2.1.1

--- a/{{cookiecutter.package_name}}/.gitignore
+++ b/{{cookiecutter.package_name}}/.gitignore
@@ -9,7 +9,7 @@ venv
 media/
 .backups/
 .envrc
-.pdm-python
+.python-version
 .terraform.lock.hcl
 .terraform/
 .nox/

--- a/{{cookiecutter.package_name}}/.gitignore
+++ b/{{cookiecutter.package_name}}/.gitignore
@@ -14,3 +14,4 @@ media/
 .terraform/
 .nox/
 __pycache__
+src/{{cookiecutter.package_name}}/_version.py

--- a/{{cookiecutter.package_name}}/README.md
+++ b/{{cookiecutter.package_name}}/README.md
@@ -22,7 +22,7 @@ Internal packages, i.e. prefixed by `{{cookiecutter.package_name}}._` do not sha
 
 
 Pre-requisites:
-- [pdm](https://pdm.fming.dev/)
+- [uv](https://docs.astral.sh/uv/)
 - [nox](https://nox.thea.codes/en/stable/)
 - [docker](https://www.docker.com/) and [docker compose plugin](https://docs.docker.com/compose/)
 
@@ -35,7 +35,7 @@ nox -t check # equivalent to `nox -t format lint test`
 
 If you wish to install dependencies into `.venv` so your IDE can pick them up, you can do so using:
 ```
-pdm install --dev
+uv sync --all-extras --dev
 ```
 
 ### Release process

--- a/{{cookiecutter.package_name}}/noxfile.py
+++ b/{{cookiecutter.package_name}}/noxfile.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import nox
 
-os.environ["PDM_IGNORE_SAVED_PYTHON"] = "1"
 
 CI = os.environ.get("CI") is not None
 
@@ -47,7 +46,7 @@ def install(session: nox.Session, *groups, dev: bool = True, editable: bool = Fa
         other_args.append("--no-default")
     for group in groups:
         other_args.extend(["--group", group])
-    session.run("pdm", "install", "--check", *other_args, external=True)
+    session.run("uv", "sync", *other_args, external=True)
 
 
 @functools.lru_cache

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -35,8 +35,10 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
+
 # COOKIECUTTER{% if cookiecutter.build_docker_image == "y" %}
-root = "/app"
+[tool.setuptools_scm]
+search_parent_directories = true
 # COOKIECUTTER{% endif %}
 
 [tool.hatch.build.hooks.vcs]

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -37,8 +37,6 @@ build-backend = "hatchling.build"
 source = "vcs"
 fallback-version = "0.0.0"
 
-[tool.setuptools_scm]
-search_parent_directories = true
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/{{cookiecutter.package_name}}/_version.py"

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -35,11 +35,10 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
+fallback-version = "0.0.0"
 
-# COOKIECUTTER{% if cookiecutter.build_docker_image == "y" %}
 [tool.setuptools_scm]
 search_parent_directories = true
-# COOKIECUTTER{% endif %}
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/{{cookiecutter.package_name}}/_version.py"

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -30,16 +30,19 @@ dependencies = [
 "Issue Tracker" = "{{cookiecutter.repository_github_url}}/issues"
 
 [build-system]
-requires = ["pdm-backend"]
-build-backend = "pdm.backend"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
-[tool.pdm]
-distribution = true
+[tool.hatch.version]
+source = "vcs"
+# COOKIECUTTER{% if cookiecutter.build_docker_image == "y" %}
+root = "/app"
+# COOKIECUTTER{% endif %}
 
-[tool.pdm.version]
-source = "scm"
+[tool.hatch.build.hooks.vcs]
+version-file = "src/{{cookiecutter.package_name}}/_version.py"
 
-[tool.pdm.dev-dependencies]
+[dependency-groups]
 test = [
     "freezegun",
     "pytest",
@@ -92,8 +95,9 @@ ignore = [
 "test/**" = ["D", "F403", "F405"]
 
 [tool.codespell]
-skip = "*.min.js,pdm.lock"
+skip = "*.min.js,uv.lock"
 ignore-words-list = "datas"
+
 
 [tool.towncrier]
 directory = "changelog.d"


### PR DESCRIPTION
This change will replace **PDM** with **UV**

## Testing scenario

**Prerequisites**: `uv` must be available

Run the `cruft` command:

```
$ cruft create https://github.com/alex-sobolev-reef/cookiecutter-rt-pkg.git \
          --checkout feature/COM-699-replace-pdb-to-uv
```

### Usage:

#### Create django app from template:

<details>

<summary>$ cruft create https://github.com/alex-sobolev-reef/cookiecutter-rt-pkg.git --checkout feature/COM-699-replace-pdb-to-uv</summary>

```bash
  [1/4] package_name (package_name): demo_django_app
  [2/4] repository_github_url (https://github.com/reef-technologies/package-name): https://github.com/reef-technologies/demo-django-app
  [3/4] is_django_package (n): y
  [4/4] build_docker_image (n): n
django_support=True
Initialized empty Git repository in /Users/s0b0lev/reef/tools/demo/demo_new/demo_django_app/.git/
[master (root-commit) 5b3938b] Initial commit
 25 files changed, 771 insertions(+)
 create mode 100644 .github/dependabot.yml
 create mode 100644 .github/workflows/ci.yml
 create mode 100644 .github/workflows/publish.yml
 create mode 100644 .gitignore
 create mode 100644 .shellcheckrc
 create mode 100644 CHANGELOG.md
 create mode 100644 README.md
 create mode 100644 SECURITY.md
 create mode 100644 docs/3rd_party/cookiecutter-rt-pkg/CHANGELOG.md
 create mode 100644 noxfile.py
 create mode 100644 pyproject.toml
 create mode 100644 src/demo_django_app/__init__.py
 create mode 100644 src/demo_django_app/_internal/__init__.py
 create mode 100644 src/demo_django_app/py.typed
 create mode 100644 src/demo_django_app/v1/__init__.py
 create mode 100644 tests/__init__.py
 create mode 100644 tests/conftest.py
 create mode 100644 tests/django_fixtures.py
 create mode 100644 tests/settings.py
 create mode 100644 tests/unit/__init__.py
 create mode 100644 tests/unit/api/__init__.py
 create mode 100644 tests/unit/api/test_setup.py
 create mode 100644 tests/unit/internal/__init__.py
 create mode 100644 tests/unit/internal/test_django_setup.py
 create mode 100644 tests/unit/internal/test_setup.py
warning: `VIRTUAL_ENV=/Users/s0b0lev/reef/tools/demo/demo/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Using CPython 3.12.0
Creating virtual environment at: .venv
Resolved 36 packages in 1.03s
      Built demo-django-app @ file:///Users/s0b0lev/reef/tools/demo/demo_new/demo_django_app
Prepared 1 package in 180ms
Installed 1 package in 1ms
 + demo-django-app==0.1.dev1+g5b3938ba4 (from file:///Users/s0b0lev/reef/tools/demo/demo_new/demo_django_app)
Resolved 36 packages in 1.46s
```

</details>


#### Create a package with Docker

<details>
<summary>$ cruft create https://github.com/alex-sobolev-reef/cookiecutter-rt-pkg.git --checkout feature/COM-699-replace-pdb-to-uv</summary>

```bash
[1/4] package_name (package_name): uv_demo
[2/4] repository_github_url (https://github.com/reef-technologies/package-name): https://github.com/reef-technologies/uv-demo
[3/4] is_django_package (n): n
[4/4] build_docker_image (n): y

django_support=False
Removing django specific /Users/s0b0lev/reef/tools/demo/demo_new/uv_demo/tests/django_fixtures.py
Removing django specific /Users/s0b0lev/reef/tools/demo/demo_new/uv_demo/tests/settings.py
Removing django specific /Users/s0b0lev/reef/tools/demo/demo_new/uv_demo/tests/unit/internal/test_django_setup.py
Initialized empty Git repository in /Users/s0b0lev/reef/tools/demo/demo_new/uv_demo/.git/
[master (root-commit) b679284] Initial commit
 24 files changed, 824 insertions(+)
 create mode 100644 .dockerignore
 create mode 100644 .github/dependabot.yml
 create mode 100644 .github/workflows/ci.yml
 create mode 100644 .github/workflows/publish.yml
 create mode 100644 .gitignore
 create mode 100644 .shellcheckrc
 create mode 100644 CHANGELOG.md
 create mode 100644 Dockerfile
 create mode 100644 README.md
 create mode 100644 SECURITY.md
 create mode 100644 docs/3rd_party/cookiecutter-rt-pkg/CHANGELOG.md
 create mode 100644 noxfile.py
 create mode 100644 pyproject.toml
 create mode 100644 src/uv_demo/__init__.py
 create mode 100644 src/uv_demo/_internal/__init__.py
 create mode 100644 src/uv_demo/py.typed
 create mode 100644 src/uv_demo/v1/__init__.py
 create mode 100644 tests/__init__.py
 create mode 100644 tests/conftest.py
 create mode 100644 tests/unit/__init__.py
 create mode 100644 tests/unit/api/__init__.py
 create mode 100644 tests/unit/api/test_setup.py
 create mode 100644 tests/unit/internal/__init__.py
 create mode 100644 tests/unit/internal/test_setup.py
warning: `VIRTUAL_ENV=/Users/s0b0lev/reef/tools/demo/demo/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Using CPython 3.12.0
Creating virtual environment at: .venv
Resolved 28 packages in 458ms
      Built uv-demo @ file:///Users/s0b0lev/reef/tools/demo/demo_new/uv_demo
Prepared 1 package in 165ms
Installed 1 package in 1ms
 + uv-demo==0.1.dev1+gb679284c3 (from file:///Users/s0b0lev/reef/tools/demo/demo_new/uv_demo)
Resolved 28 packages in 1.43s

$ docker build --tag demouv/app . --no-cache
[+] Building 45.1s (17/17) FINISHED
=> [internal] load build definition from Dockerfile
=> => transferring dockerfile: 1.11kB
=> [internal] load metadata for docker.io/library/python:3.12-alpine
=> [internal] load .dockerignore
=> => transferring context: 211B
=> CACHED [builder  1/10] FROM docker.io/library/python:3.12-alpine@sha256:02a73ead8397e904cea6d17e18516f1df3590e05dc8823bd5b1c7f849227d272                                                                                                                                             0.0s
=> [internal] load build context
=> => transferring context: 122.92kB
=> CACHED [builder  2/10] WORKDIR /app
=> [builder  3/10] RUN apk add --no-cache     curl     gcc     musl-dev     libffi-dev     openssl-dev     git                                                                                                                                                                         20.1s
=> [builder  4/10] RUN pip install --no-cache-dir uv
=> [builder  5/10] COPY . .
=> [builder  6/10] RUN uv export --format requirements-txt > /tmp/requirements.txt
=> [builder  7/10] RUN uv build --wheel --out-dir /tmp/wheelhouse
=> [builder  8/10] RUN pip install --no-cache-dir -r /tmp/requirements.txt
=> [builder  9/10] RUN pip install --no-cache-dir --no-deps /tmp/wheelhouse/*.whl
=> [builder 10/10] RUN sed '/^\./d' /tmp/requirements.txt > /tmp/requirements-clean.txt && pip install --no-cache-dir -r /tmp/requirements-clean.txt                                                                                                                                    4.1s
=> [stage-1 2/3] COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages                                                                                                                                                                    0.1s
=> [stage-1 3/3] COPY --from=builder /usr/local/bin /usr/local/bin
=> exporting to image
=> => exporting layers
=> => writing image sha256:86625e454aea82cd51baaab56168c0a377e4b13ea12c7b3ca74390cd0f6bfe9d
=> => naming to docker.io/demouv/app

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/gr4oiyrkoirbsznwygekbh8cp

What's next:
  View a summary of image vulnerabilities and recommendations → docker scout quickview
```

</details>
