### PR TITLE
fix: resolve nox error with uv support

### DIFF
--- a/{{cookiecutter.package_name}}/noxfile.py
+++ b/{{cookiecutter.package_name}}/noxfile.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import nox
 
-
 CI = os.environ.get("CI") is not None
 
 ROOT = Path(".")
@@ -46,7 +45,7 @@ def install(session: nox.Session, *groups, dev: bool = True, editable: bool = Fa
         other_args.append("--no-default")
     for group in groups:
         other_args.extend(["--group", group])
-    session.run("uv", "sync", *other_args, external=True)
+    session.run("uv", "sync", "--active", *other_args, external=True)
 
 
 @functools.lru_cache


### PR DESCRIPTION
The nox issue was resolved:

<details>
<summary>
$ nox -vt crufted_project
</summary>

```shell
nox > Running session lint_crufted_project(cruft_config_name='default')
nox > Re-using existing virtual environment at .nox/lint_crufted_project-cruft_config_name-default.
nox > pip install -e .
Obtaining file:///Users/<user>/reef/tools/cookiecutter-rt-pkg
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: codespell in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (2.4.1)
Requirement already satisfied: cruft in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (2.16.0)
Requirement already satisfied: nox in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (2025.5.1)
Requirement already satisfied: ruff in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (0.13.0)
Requirement already satisfied: click>=7.1.2 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (8.2.1)
Requirement already satisfied: cookiecutter>=1.7 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (2.6.0)
Requirement already satisfied: gitpython>=3.0 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (3.1.45)
Requirement already satisfied: typer>=0.4.0 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (0.17.4)
Requirement already satisfied: argcomplete<4,>=1.9.4 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (3.6.2)
Requirement already satisfied: attrs>=23.1 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (25.3.0)
Requirement already satisfied: colorlog<7,>=2.6.1 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (6.9.0)
Requirement already satisfied: dependency-groups>=1.1 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (1.3.1)
Requirement already satisfied: packaging>=20.9 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (25.0)
Requirement already satisfied: virtualenv>=20.14.1 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (20.34.0)
Requirement already satisfied: binaryornot>=0.4.4 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (0.4.4)
Requirement already satisfied: Jinja2<4.0.0,>=2.7 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.1.6)
Requirement already satisfied: pyyaml>=5.3.1 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (6.0.2)
Requirement already satisfied: python-slugify>=4.0.0 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (8.0.4)
Requirement already satisfied: requests>=2.23.0 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.32.5)
Requirement already satisfied: arrow in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (1.3.0)
Requirement already satisfied: rich in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (14.1.0)
Requirement already satisfied: gitdb<5,>=4.0.1 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from gitpython>=3.0->cruft->cookiecutter-rt-pkg==0) (4.0.12)
Requirement already satisfied: typing-extensions>=3.7.4.3 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from typer>=0.4.0->cruft->cookiecutter-rt-pkg==0) (4.15.0)
Requirement already satisfied: shellingham>=1.3.0 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from typer>=0.4.0->cruft->cookiecutter-rt-pkg==0) (1.5.4)
Requirement already satisfied: distlib<1,>=0.3.7 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from virtualenv>=20.14.1->nox->cookiecutter-rt-pkg==0) (0.4.0)
Requirement already satisfied: filelock<4,>=3.12.2 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from virtualenv>=20.14.1->nox->cookiecutter-rt-pkg==0) (3.19.1)
Requirement already satisfied: platformdirs<5,>=3.9.1 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from virtualenv>=20.14.1->nox->cookiecutter-rt-pkg==0) (4.4.0)
Requirement already satisfied: chardet>=3.0.2 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from binaryornot>=0.4.4->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (5.2.0)
Requirement already satisfied: smmap<6,>=3.0.1 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from gitdb<5,>=4.0.1->gitpython>=3.0->cruft->cookiecutter-rt-pkg==0) (5.0.2)
Requirement already satisfied: MarkupSafe>=2.0 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from Jinja2<4.0.0,>=2.7->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.0.2)
Requirement already satisfied: text-unidecode>=1.3 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from python-slugify>=4.0.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (1.3)
Requirement already satisfied: charset_normalizer<4,>=2 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.4.3)
Requirement already satisfied: idna<4,>=2.5 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.10)
Requirement already satisfied: urllib3<3,>=1.21.1 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.5.0)
Requirement already satisfied: certifi>=2017.4.17 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2025.8.3)
Requirement already satisfied: markdown-it-py>=2.2.0 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from rich->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (4.0.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from rich->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.19.2)
Requirement already satisfied: python-dateutil>=2.7.0 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from arrow->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.9.0.post0)
Requirement already satisfied: types-python-dateutil>=2.8.10 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from arrow->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.9.0.20250822)
Requirement already satisfied: mdurl~=0.1 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (0.1.2)
Requirement already satisfied: six>=1.5 in ./.nox/lint_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from python-dateutil>=2.7.0->arrow->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (1.17.0)
Building wheels for collected packages: cookiecutter-rt-pkg
  Building editable for cookiecutter-rt-pkg (pyproject.toml) ... done
  Created wheel for cookiecutter-rt-pkg: filename=cookiecutter_rt_pkg-0-0.editable-py3-none-any.whl size=4713 sha256=ef9fd18c3025c38150991ebe403e26e47f618f774a0683b4bd52abe3bbdfa604
  Stored in directory: /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/pip-ephem-wheel-cache-cgn0yt_y/wheels/d1/56/36/79a3788ebea273a8420d79382f4508bed534036129c8fdafe2
Successfully built cookiecutter-rt-pkg
Installing collected packages: cookiecutter-rt-pkg
  Attempting uninstall: cookiecutter-rt-pkg
    Found existing installation: cookiecutter-rt-pkg 0
    Uninstalling cookiecutter-rt-pkg-0:
      Successfully uninstalled cookiecutter-rt-pkg-0
Successfully installed cookiecutter-rt-pkg-0

[notice] A new release of pip is available: 25.0.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
nox > Creating project in /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1
nox > Found dirty git repository, temporarily committing changes in /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_tmpl_reporkio8u0d
nox > cd /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_tmpl_reporkio8u0d
[feature/COM-699-fix-nox-error 0f9f737] nox: dirty commit
 1 file changed, 1 insertion(+), 2 deletions(-)
nox > cruft create . --output-dir /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1 --no-input --extra-context '{"package_name": "default_4d2b959d", "repository_github_url": "https://github.com/reef-technologies/default-4d2b959d", "is_django_package": "n", "build_docker_image": "n", "_jinja2_env_vars": {"block_start_string": "# COOKIECUTTER{%", "block_end_string": "%}"}}'
django_support=False
Removing django specific /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d/tests/django_fixtures.py
Removing django specific /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d/tests/settings.py
Removing django specific /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d/tests/unit/internal/test_django_setup.py
warning: `VIRTUAL_ENV=/Users/<user>/reef/tools/cookiecutter-rt-pkg/.nox/lint_crufted_project-cruft_config_name-default` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Using CPython 3.12.0
Creating virtual environment at: .venv
Resolved 28 packages in 445ms
      Built default-4d2b959d @ file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d
Prepared 1 package in 113ms
Installed 1 package in 1ms
 + default-4d2b959d==0.0.0 (from file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d)
Resolved 28 packages in 1.43s
nox > cd /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d
nox > git init
Initialized empty Git repository in /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d/.git/
nox > cd /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d
nox > nox -t lint
nox > Running session lint
nox > Creating virtual environment (venv) using python3.12 in .nox/lint
nox > uv sync --active --no-editable --group lint --group test
Resolved 28 packages in 0.59ms
      Built default-4d2b959d @ file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d
Prepared 1 package in 441ms
Installed 23 packages in 45ms
 + codespell==2.4.1
 + default-4d2b959d==0.0.1.dev0+d20250916 (from file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d)
 + execnet==2.1.1
 + freezegun==1.5.5
 + iniconfig==2.1.0
 + mypy==1.18.1
 + mypy-extensions==1.1.0
 + packaging==25.0
 + pathspec==0.12.1
 + pluggy==1.6.0
 + pygments==2.19.2
 + pytest==8.4.2
 + pytest-apiver==0.1.0
 + pytest-asyncio==1.2.0
 + pytest-xdist==3.8.0
 + python-dateutil==2.9.0.post0
 + ruff==0.13.0
 + six==1.17.0
 + types-freezegun==1.1.10
 + types-python-dateutil==2.9.0.20250822
 + types-requests==2.32.4.20250913
 + typing-extensions==4.15.0
 + urllib3==2.5.0
nox > ruff check --diff --unsafe-fixes .
warning: `TCH005` has been remapped to `TC005`.
nox > ruff format --diff .
warning: `TCH005` has been remapped to `TC005`.
11 files already formatted
nox > mypy .
Success: no issues found in 12 source files
nox > codespell .
nox > No shell files found
nox > docker run --platform linux/amd64 --rm -v /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d:/data -w /data ghcr.io/bobheadxi/readable:v0.5.0@sha256:423c133e7e9ca0ac20b0ab298bd5dbfa3df09b515b34cbfbbe8944310cc8d9c9 check '![.]**/*.md'
nox > Session lint was successful.
nox > Session lint_crufted_project(cruft_config_name='default') was successful.
nox > Running session lint_crufted_project(cruft_config_name='django')
nox > Re-using existing virtual environment at .nox/lint_crufted_project-cruft_config_name-django.
nox > pip install -e .
Obtaining file:///Users/<user>/reef/tools/cookiecutter-rt-pkg
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: codespell in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (2.4.1)
Requirement already satisfied: cruft in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (2.16.0)
Requirement already satisfied: nox in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (2025.5.1)
Requirement already satisfied: ruff in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (0.13.0)
Requirement already satisfied: click>=7.1.2 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (8.2.1)
Requirement already satisfied: cookiecutter>=1.7 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (2.6.0)
Requirement already satisfied: gitpython>=3.0 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (3.1.45)
Requirement already satisfied: typer>=0.4.0 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (0.17.4)
Requirement already satisfied: argcomplete<4,>=1.9.4 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (3.6.2)
Requirement already satisfied: attrs>=23.1 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (25.3.0)
Requirement already satisfied: colorlog<7,>=2.6.1 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (6.9.0)
Requirement already satisfied: dependency-groups>=1.1 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (1.3.1)
Requirement already satisfied: packaging>=20.9 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (25.0)
Requirement already satisfied: virtualenv>=20.14.1 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (20.34.0)
Requirement already satisfied: binaryornot>=0.4.4 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (0.4.4)
Requirement already satisfied: Jinja2<4.0.0,>=2.7 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.1.6)
Requirement already satisfied: pyyaml>=5.3.1 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (6.0.2)
Requirement already satisfied: python-slugify>=4.0.0 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (8.0.4)
Requirement already satisfied: requests>=2.23.0 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.32.5)
Requirement already satisfied: arrow in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (1.3.0)
Requirement already satisfied: rich in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (14.1.0)
Requirement already satisfied: gitdb<5,>=4.0.1 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from gitpython>=3.0->cruft->cookiecutter-rt-pkg==0) (4.0.12)
Requirement already satisfied: typing-extensions>=3.7.4.3 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from typer>=0.4.0->cruft->cookiecutter-rt-pkg==0) (4.15.0)
Requirement already satisfied: shellingham>=1.3.0 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from typer>=0.4.0->cruft->cookiecutter-rt-pkg==0) (1.5.4)
Requirement already satisfied: distlib<1,>=0.3.7 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from virtualenv>=20.14.1->nox->cookiecutter-rt-pkg==0) (0.4.0)
Requirement already satisfied: filelock<4,>=3.12.2 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from virtualenv>=20.14.1->nox->cookiecutter-rt-pkg==0) (3.19.1)
Requirement already satisfied: platformdirs<5,>=3.9.1 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from virtualenv>=20.14.1->nox->cookiecutter-rt-pkg==0) (4.4.0)
Requirement already satisfied: chardet>=3.0.2 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from binaryornot>=0.4.4->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (5.2.0)
Requirement already satisfied: smmap<6,>=3.0.1 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from gitdb<5,>=4.0.1->gitpython>=3.0->cruft->cookiecutter-rt-pkg==0) (5.0.2)
Requirement already satisfied: MarkupSafe>=2.0 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from Jinja2<4.0.0,>=2.7->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.0.2)
Requirement already satisfied: text-unidecode>=1.3 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from python-slugify>=4.0.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (1.3)
Requirement already satisfied: charset_normalizer<4,>=2 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.4.3)
Requirement already satisfied: idna<4,>=2.5 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.10)
Requirement already satisfied: urllib3<3,>=1.21.1 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.5.0)
Requirement already satisfied: certifi>=2017.4.17 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2025.8.3)
Requirement already satisfied: markdown-it-py>=2.2.0 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from rich->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (4.0.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from rich->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.19.2)
Requirement already satisfied: python-dateutil>=2.7.0 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from arrow->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.9.0.post0)
Requirement already satisfied: types-python-dateutil>=2.8.10 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from arrow->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.9.0.20250822)
Requirement already satisfied: mdurl~=0.1 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (0.1.2)
Requirement already satisfied: six>=1.5 in ./.nox/lint_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from python-dateutil>=2.7.0->arrow->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (1.17.0)
Building wheels for collected packages: cookiecutter-rt-pkg
  Building editable for cookiecutter-rt-pkg (pyproject.toml) ... done
  Created wheel for cookiecutter-rt-pkg: filename=cookiecutter_rt_pkg-0-0.editable-py3-none-any.whl size=4713 sha256=4396585aa86337812e40a5afa1381ca814bded7ba8bd6d4578b62d2e9f0658e3
  Stored in directory: /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/pip-ephem-wheel-cache-yz2vjv1i/wheels/d1/56/36/79a3788ebea273a8420d79382f4508bed534036129c8fdafe2
Successfully built cookiecutter-rt-pkg
Installing collected packages: cookiecutter-rt-pkg
  Attempting uninstall: cookiecutter-rt-pkg
    Found existing installation: cookiecutter-rt-pkg 0
    Uninstalling cookiecutter-rt-pkg-0:
      Successfully uninstalled cookiecutter-rt-pkg-0
Successfully installed cookiecutter-rt-pkg-0

[notice] A new release of pip is available: 25.0.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
nox > Creating project in /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1
nox > Found dirty git repository, temporarily committing changes in /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_tmpl_repo3ks1rnmh
nox > cd /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_tmpl_repo3ks1rnmh
[feature/COM-699-fix-nox-error 8cea608] nox: dirty commit
 1 file changed, 1 insertion(+), 2 deletions(-)
nox > cruft create . --output-dir /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1 --no-input --extra-context '{"package_name": "django_b54c8ff5", "repository_github_url": "https://github.com/reef-technologies/django-b54c8ff5", "is_django_package": "y", "build_docker_image": "n", "_jinja2_env_vars": {"block_start_string": "# COOKIECUTTER{%", "block_end_string": "%}"}}'
django_support=True
warning: `VIRTUAL_ENV=/Users/<user>/reef/tools/cookiecutter-rt-pkg/.nox/lint_crufted_project-cruft_config_name-django` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Using CPython 3.12.0
Creating virtual environment at: .venv
Resolved 36 packages in 412ms
      Built django-b54c8ff5 @ file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5
Prepared 1 package in 110ms
Installed 1 package in 1ms
 + django-b54c8ff5==0.0.0 (from file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5)
Resolved 36 packages in 1.25s
nox > cd /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5
nox > git init
Initialized empty Git repository in /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5/.git/
nox > cd /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5
nox > nox -t lint
nox > Running session lint
nox > Creating virtual environment (venv) using python3.12 in .nox/lint
nox > uv sync --active --no-editable --group lint --group test
Resolved 36 packages in 0.85ms
      Built django-b54c8ff5 @ file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5
Prepared 1 package in 406ms
Installed 30 packages in 239ms
 + asgiref==3.9.1
 + codespell==2.4.1
 + django==5.2.6
 + django-b54c8ff5==0.0.1.dev0+d20250916 (from file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5)
 + django-stubs==5.2.5
 + django-stubs-ext==5.2.5
 + execnet==2.1.1
 + freezegun==1.5.5
 + iniconfig==2.1.0
 + mypy==1.18.1
 + mypy-extensions==1.1.0
 + packaging==25.0
 + pathspec==0.12.1
 + pluggy==1.6.0
 + pygments==2.19.2
 + pytest==8.4.2
 + pytest-apiver==0.1.0
 + pytest-asyncio==1.2.0
 + pytest-django==4.11.1
 + pytest-xdist==3.8.0
 + python-dateutil==2.9.0.post0
 + ruff==0.13.0
 + six==1.17.0
 + sqlparse==0.5.3
 + types-freezegun==1.1.10
 + types-python-dateutil==2.9.0.20250822
 + types-pyyaml==6.0.12.20250915
 + types-requests==2.32.4.20250913
 + typing-extensions==4.15.0
 + urllib3==2.5.0
nox > ruff check --diff --unsafe-fixes .
warning: `TCH005` has been remapped to `TC005`.
nox > ruff format --diff .
warning: `TCH005` has been remapped to `TC005`.
14 files already formatted
nox > mypy .
Success: no issues found in 15 source files
nox > codespell .
nox > No shell files found
nox > docker run --platform linux/amd64 --rm -v /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5:/data -w /data ghcr.io/bobheadxi/readable:v0.5.0@sha256:423c133e7e9ca0ac20b0ab298bd5dbfa3df09b515b34cbfbbe8944310cc8d9c9 check '![.]**/*.md'
nox > Session lint was successful.
nox > Session lint_crufted_project(cruft_config_name='django') was successful.
nox > Running session test_crufted_project(cruft_config_name='default')
nox > Re-using existing virtual environment at .nox/test_crufted_project-cruft_config_name-default.
nox > pip install -e .
Obtaining file:///Users/<user>/reef/tools/cookiecutter-rt-pkg
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: codespell in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (2.4.1)
Requirement already satisfied: cruft in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (2.16.0)
Requirement already satisfied: nox in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (2025.5.1)
Requirement already satisfied: ruff in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (0.13.0)
Requirement already satisfied: click>=7.1.2 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (8.2.1)
Requirement already satisfied: cookiecutter>=1.7 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (2.6.0)
Requirement already satisfied: gitpython>=3.0 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (3.1.45)
Requirement already satisfied: typer>=0.4.0 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (0.17.4)
Requirement already satisfied: argcomplete<4,>=1.9.4 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (3.6.2)
Requirement already satisfied: attrs>=23.1 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (25.3.0)
Requirement already satisfied: colorlog<7,>=2.6.1 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (6.9.0)
Requirement already satisfied: dependency-groups>=1.1 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (1.3.1)
Requirement already satisfied: packaging>=20.9 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (25.0)
Requirement already satisfied: virtualenv>=20.14.1 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (20.34.0)
Requirement already satisfied: binaryornot>=0.4.4 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (0.4.4)
Requirement already satisfied: Jinja2<4.0.0,>=2.7 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.1.6)
Requirement already satisfied: pyyaml>=5.3.1 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (6.0.2)
Requirement already satisfied: python-slugify>=4.0.0 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (8.0.4)
Requirement already satisfied: requests>=2.23.0 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.32.5)
Requirement already satisfied: arrow in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (1.3.0)
Requirement already satisfied: rich in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (14.1.0)
Requirement already satisfied: gitdb<5,>=4.0.1 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from gitpython>=3.0->cruft->cookiecutter-rt-pkg==0) (4.0.12)
Requirement already satisfied: typing-extensions>=3.7.4.3 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from typer>=0.4.0->cruft->cookiecutter-rt-pkg==0) (4.15.0)
Requirement already satisfied: shellingham>=1.3.0 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from typer>=0.4.0->cruft->cookiecutter-rt-pkg==0) (1.5.4)
Requirement already satisfied: distlib<1,>=0.3.7 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from virtualenv>=20.14.1->nox->cookiecutter-rt-pkg==0) (0.4.0)
Requirement already satisfied: filelock<4,>=3.12.2 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from virtualenv>=20.14.1->nox->cookiecutter-rt-pkg==0) (3.19.1)
Requirement already satisfied: platformdirs<5,>=3.9.1 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from virtualenv>=20.14.1->nox->cookiecutter-rt-pkg==0) (4.4.0)
Requirement already satisfied: chardet>=3.0.2 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from binaryornot>=0.4.4->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (5.2.0)
Requirement already satisfied: smmap<6,>=3.0.1 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from gitdb<5,>=4.0.1->gitpython>=3.0->cruft->cookiecutter-rt-pkg==0) (5.0.2)
Requirement already satisfied: MarkupSafe>=2.0 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from Jinja2<4.0.0,>=2.7->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.0.2)
Requirement already satisfied: text-unidecode>=1.3 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from python-slugify>=4.0.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (1.3)
Requirement already satisfied: charset_normalizer<4,>=2 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.4.3)
Requirement already satisfied: idna<4,>=2.5 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.10)
Requirement already satisfied: urllib3<3,>=1.21.1 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.5.0)
Requirement already satisfied: certifi>=2017.4.17 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2025.8.3)
Requirement already satisfied: markdown-it-py>=2.2.0 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from rich->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (4.0.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from rich->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.19.2)
Requirement already satisfied: python-dateutil>=2.7.0 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from arrow->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.9.0.post0)
Requirement already satisfied: types-python-dateutil>=2.8.10 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from arrow->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.9.0.20250822)
Requirement already satisfied: mdurl~=0.1 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (0.1.2)
Requirement already satisfied: six>=1.5 in ./.nox/test_crufted_project-cruft_config_name-default/lib/python3.11/site-packages (from python-dateutil>=2.7.0->arrow->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (1.17.0)
Building wheels for collected packages: cookiecutter-rt-pkg
  Building editable for cookiecutter-rt-pkg (pyproject.toml) ... done
  Created wheel for cookiecutter-rt-pkg: filename=cookiecutter_rt_pkg-0-0.editable-py3-none-any.whl size=4713 sha256=a7ba08ec5e0c6eb4c52dfe1db513574e6bbe32168d61352b9939ada0f63b8114
  Stored in directory: /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/pip-ephem-wheel-cache-s3l7ihqg/wheels/d1/56/36/79a3788ebea273a8420d79382f4508bed534036129c8fdafe2
Successfully built cookiecutter-rt-pkg
Installing collected packages: cookiecutter-rt-pkg
  Attempting uninstall: cookiecutter-rt-pkg
    Found existing installation: cookiecutter-rt-pkg 0
    Uninstalling cookiecutter-rt-pkg-0:
      Successfully uninstalled cookiecutter-rt-pkg-0
Successfully installed cookiecutter-rt-pkg-0

[notice] A new release of pip is available: 25.0.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
nox > cd /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d
nox > nox -t test
nox > Running session test-3.11
nox > Creating virtual environment (venv) using python3.11 in .nox/test-3-11
nox > uv sync --active --no-editable --group test
Resolved 28 packages in 5ms
Installed 14 packages in 13ms
 + default-4d2b959d==0.0.1.dev0+d20250916 (from file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d)
 + execnet==2.1.1
 + freezegun==1.5.5
 + iniconfig==2.1.0
 + packaging==25.0
 + pluggy==1.6.0
 + pygments==2.19.2
 + pytest==8.4.2
 + pytest-apiver==0.1.0
 + pytest-asyncio==1.2.0
 + pytest-xdist==3.8.0
 + python-dateutil==2.9.0.post0
 + six==1.17.0
 + typing-extensions==4.15.0
nox > pytest -vv -n auto
==================================================================================================================================== test session starts =====================================================================================================================================
platform darwin -- Python 3.11.12, pytest-8.4.2, pluggy-1.6.0 -- /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d/.nox/test-3-11/bin/python3
cachedir: .pytest_cache
rootdir: /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d
configfile: pyproject.toml
plugins: apiver-0.1.0, asyncio-1.2.0, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
8 workers [2 items]
scheduling tests via LoadScheduling

tests/unit/api/test_setup.py::test_apiver_exports[v1]
tests/unit/internal/test_setup.py::test__setup
[gw0] [ 50%] PASSED tests/unit/api/test_setup.py::test_apiver_exports[v1]
[gw1] [100%] PASSED tests/unit/internal/test_setup.py::test__setup

===================================================================================================================================== 2 passed in 0.77s ======================================================================================================================================
nox > Session test-3.11 was successful.
nox > Running session test-3.12
nox > Creating virtual environment (venv) using python3.12 in .nox/test-3-12
nox > uv sync --active --no-editable --group test
Resolved 28 packages in 0.58ms
Installed 14 packages in 14ms
 + default-4d2b959d==0.0.1.dev0+d20250916 (from file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d)
 + execnet==2.1.1
 + freezegun==1.5.5
 + iniconfig==2.1.0
 + packaging==25.0
 + pluggy==1.6.0
 + pygments==2.19.2
 + pytest==8.4.2
 + pytest-apiver==0.1.0
 + pytest-asyncio==1.2.0
 + pytest-xdist==3.8.0
 + python-dateutil==2.9.0.post0
 + six==1.17.0
 + typing-extensions==4.15.0
nox > pytest -vv -n auto
==================================================================================================================================== test session starts =====================================================================================================================================
platform darwin -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d/.nox/test-3-12/bin/python3
cachedir: .pytest_cache
rootdir: /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/default_4d2b959d
configfile: pyproject.toml
plugins: apiver-0.1.0, asyncio-1.2.0, xdist-3.8.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
8 workers [2 items]
scheduling tests via LoadScheduling

tests/unit/api/test_setup.py::test_apiver_exports[v1]
tests/unit/internal/test_setup.py::test__setup
[gw0] [ 50%] PASSED tests/unit/api/test_setup.py::test_apiver_exports[v1]
[gw1] [100%] PASSED tests/unit/internal/test_setup.py::test__setup

===================================================================================================================================== 2 passed in 0.89s ======================================================================================================================================
nox > Session test-3.12 was successful.
nox > Ran multiple sessions:
nox > * test-3.11: success
nox > * test-3.12: success
nox > Session test_crufted_project(cruft_config_name='default') was successful.
nox > Running session test_crufted_project(cruft_config_name='django')
nox > Re-using existing virtual environment at .nox/test_crufted_project-cruft_config_name-django.
nox > pip install -e .
Obtaining file:///Users/<user>/reef/tools/cookiecutter-rt-pkg
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: codespell in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (2.4.1)
Requirement already satisfied: cruft in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (2.16.0)
Requirement already satisfied: nox in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (2025.5.1)
Requirement already satisfied: ruff in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter-rt-pkg==0) (0.13.0)
Requirement already satisfied: click>=7.1.2 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (8.2.1)
Requirement already satisfied: cookiecutter>=1.7 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (2.6.0)
Requirement already satisfied: gitpython>=3.0 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (3.1.45)
Requirement already satisfied: typer>=0.4.0 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cruft->cookiecutter-rt-pkg==0) (0.17.4)
Requirement already satisfied: argcomplete<4,>=1.9.4 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (3.6.2)
Requirement already satisfied: attrs>=23.1 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (25.3.0)
Requirement already satisfied: colorlog<7,>=2.6.1 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (6.9.0)
Requirement already satisfied: dependency-groups>=1.1 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (1.3.1)
Requirement already satisfied: packaging>=20.9 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (25.0)
Requirement already satisfied: virtualenv>=20.14.1 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from nox->cookiecutter-rt-pkg==0) (20.34.0)
Requirement already satisfied: binaryornot>=0.4.4 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (0.4.4)
Requirement already satisfied: Jinja2<4.0.0,>=2.7 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.1.6)
Requirement already satisfied: pyyaml>=5.3.1 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (6.0.2)
Requirement already satisfied: python-slugify>=4.0.0 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (8.0.4)
Requirement already satisfied: requests>=2.23.0 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.32.5)
Requirement already satisfied: arrow in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (1.3.0)
Requirement already satisfied: rich in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (14.1.0)
Requirement already satisfied: gitdb<5,>=4.0.1 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from gitpython>=3.0->cruft->cookiecutter-rt-pkg==0) (4.0.12)
Requirement already satisfied: typing-extensions>=3.7.4.3 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from typer>=0.4.0->cruft->cookiecutter-rt-pkg==0) (4.15.0)
Requirement already satisfied: shellingham>=1.3.0 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from typer>=0.4.0->cruft->cookiecutter-rt-pkg==0) (1.5.4)
Requirement already satisfied: distlib<1,>=0.3.7 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from virtualenv>=20.14.1->nox->cookiecutter-rt-pkg==0) (0.4.0)
Requirement already satisfied: filelock<4,>=3.12.2 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from virtualenv>=20.14.1->nox->cookiecutter-rt-pkg==0) (3.19.1)
Requirement already satisfied: platformdirs<5,>=3.9.1 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from virtualenv>=20.14.1->nox->cookiecutter-rt-pkg==0) (4.4.0)
Requirement already satisfied: chardet>=3.0.2 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from binaryornot>=0.4.4->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (5.2.0)
Requirement already satisfied: smmap<6,>=3.0.1 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from gitdb<5,>=4.0.1->gitpython>=3.0->cruft->cookiecutter-rt-pkg==0) (5.0.2)
Requirement already satisfied: MarkupSafe>=2.0 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from Jinja2<4.0.0,>=2.7->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.0.2)
Requirement already satisfied: text-unidecode>=1.3 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from python-slugify>=4.0.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (1.3)
Requirement already satisfied: charset_normalizer<4,>=2 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.4.3)
Requirement already satisfied: idna<4,>=2.5 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (3.10)
Requirement already satisfied: urllib3<3,>=1.21.1 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.5.0)
Requirement already satisfied: certifi>=2017.4.17 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from requests>=2.23.0->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2025.8.3)
Requirement already satisfied: markdown-it-py>=2.2.0 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from rich->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (4.0.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from rich->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.19.2)
Requirement already satisfied: python-dateutil>=2.7.0 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from arrow->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.9.0.post0)
Requirement already satisfied: types-python-dateutil>=2.8.10 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from arrow->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (2.9.0.20250822)
Requirement already satisfied: mdurl~=0.1 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (0.1.2)
Requirement already satisfied: six>=1.5 in ./.nox/test_crufted_project-cruft_config_name-django/lib/python3.11/site-packages (from python-dateutil>=2.7.0->arrow->cookiecutter>=1.7->cruft->cookiecutter-rt-pkg==0) (1.17.0)
Building wheels for collected packages: cookiecutter-rt-pkg
  Building editable for cookiecutter-rt-pkg (pyproject.toml) ... done
  Created wheel for cookiecutter-rt-pkg: filename=cookiecutter_rt_pkg-0-0.editable-py3-none-any.whl size=4713 sha256=b1e578b6ff0a86fefb2d7c3935513491bdde67184b38838eb27bd9e77328c2aa
  Stored in directory: /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/pip-ephem-wheel-cache-8z2zrt8g/wheels/d1/56/36/79a3788ebea273a8420d79382f4508bed534036129c8fdafe2
Successfully built cookiecutter-rt-pkg
Installing collected packages: cookiecutter-rt-pkg
  Attempting uninstall: cookiecutter-rt-pkg
    Found existing installation: cookiecutter-rt-pkg 0
    Uninstalling cookiecutter-rt-pkg-0:
      Successfully uninstalled cookiecutter-rt-pkg-0
Successfully installed cookiecutter-rt-pkg-0

[notice] A new release of pip is available: 25.0.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
nox > cd /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5
nox > nox -t test
nox > Running session test-3.11(django='3.2')
nox > Creating virtual environment (venv) using python3.11 in .nox/test-3-11-django-3-2
nox > uv sync --active --no-editable --group test
Resolved 36 packages in 0.61ms
Installed 15 packages in 10ms
 + django-b54c8ff5==0.0.1.dev0+d20250916 (from file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5)
 + execnet==2.1.1
 + freezegun==1.5.5
 + iniconfig==2.1.0
 + packaging==25.0
 + pluggy==1.6.0
 + pygments==2.19.2
 + pytest==8.4.2
 + pytest-apiver==0.1.0
 + pytest-asyncio==1.2.0
 + pytest-django==4.11.1
 + pytest-xdist==3.8.0
 + python-dateutil==2.9.0.post0
 + six==1.17.0
 + typing-extensions==4.15.0
nox > pip install 'django~=3.2.0'
Collecting django~=3.2.0
  Using cached Django-3.2.25-py3-none-any.whl.metadata (4.1 kB)
Collecting asgiref<4,>=3.3.2 (from django~=3.2.0)
  Using cached asgiref-3.9.1-py3-none-any.whl.metadata (9.3 kB)
Collecting pytz (from django~=3.2.0)
  Using cached pytz-2025.2-py2.py3-none-any.whl.metadata (22 kB)
Collecting sqlparse>=0.2.2 (from django~=3.2.0)
  Using cached sqlparse-0.5.3-py3-none-any.whl.metadata (3.9 kB)
Using cached Django-3.2.25-py3-none-any.whl (7.9 MB)
Using cached asgiref-3.9.1-py3-none-any.whl (23 kB)
Using cached sqlparse-0.5.3-py3-none-any.whl (44 kB)
Using cached pytz-2025.2-py2.py3-none-any.whl (509 kB)
Installing collected packages: pytz, sqlparse, asgiref, django
Successfully installed asgiref-3.9.1 django-3.2.25 pytz-2025.2 sqlparse-0.5.3

[notice] A new release of pip is available: 25.0.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
nox > pytest -vv -n auto
==================================================================================================================================== test session starts =====================================================================================================================================
platform darwin -- Python 3.11.12, pytest-8.4.2, pluggy-1.6.0 -- /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5/.nox/test-3-11-django-3-2/bin/python3
cachedir: .pytest_cache
django: version: 3.2.25, settings: tests.settings (from ini)
rootdir: /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5
configfile: pyproject.toml
plugins: apiver-0.1.0, asyncio-1.2.0, xdist-3.8.0, django-4.11.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
8 workers [3 items]
scheduling tests via LoadScheduling

tests/unit/internal/test_django_setup.py::test__setup
tests/unit/api/test_setup.py::test_apiver_exports[v1]
tests/unit/internal/test_setup.py::test__setup
[gw1] [ 33%] PASSED tests/unit/api/test_setup.py::test_apiver_exports[v1]
[gw2] [ 66%] PASSED tests/unit/internal/test_setup.py::test__setup
[gw0] [100%] PASSED tests/unit/internal/test_django_setup.py::test__setup

====================================================================================================================================== warnings summary ======================================================================================================================================
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/http/request.py:1
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/http/request.py:1
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/http/request.py:1
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/http/request.py:1
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/http/request.py:1
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/http/request.py:1
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/http/request.py:1
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/http/request.py:1
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/http/request.py:1
  /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5/.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/utils/encoding.py:268
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/utils/encoding.py:268
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/utils/encoding.py:268
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/utils/encoding.py:268
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/utils/encoding.py:268
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/utils/encoding.py:268
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/utils/encoding.py:268
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/utils/encoding.py:268
.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/utils/encoding.py:268
  /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5/.nox/test-3-11-django-3-2/lib/python3.11/site-packages/django/utils/encoding.py:268: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================================================== 3 passed, 18 warnings in 1.22s ===============================================================================================================================
nox > Session test-3.11(django='3.2') was successful.
nox > Running session test-3.11(django='4.2')
nox > Creating virtual environment (venv) using python3.11 in .nox/test-3-11-django-4-2
nox > uv sync --active --no-editable --group test
Resolved 36 packages in 0.54ms
Installed 15 packages in 10ms
 + django-b54c8ff5==0.0.1.dev0+d20250916 (from file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5)
 + execnet==2.1.1
 + freezegun==1.5.5
 + iniconfig==2.1.0
 + packaging==25.0
 + pluggy==1.6.0
 + pygments==2.19.2
 + pytest==8.4.2
 + pytest-apiver==0.1.0
 + pytest-asyncio==1.2.0
 + pytest-django==4.11.1
 + pytest-xdist==3.8.0
 + python-dateutil==2.9.0.post0
 + six==1.17.0
 + typing-extensions==4.15.0
nox > pip install 'django~=4.2.0'
Collecting django~=4.2.0
  Using cached django-4.2.24-py3-none-any.whl.metadata (4.2 kB)
Collecting asgiref<4,>=3.6.0 (from django~=4.2.0)
  Using cached asgiref-3.9.1-py3-none-any.whl.metadata (9.3 kB)
Collecting sqlparse>=0.3.1 (from django~=4.2.0)
  Using cached sqlparse-0.5.3-py3-none-any.whl.metadata (3.9 kB)
Using cached django-4.2.24-py3-none-any.whl (8.0 MB)
Using cached asgiref-3.9.1-py3-none-any.whl (23 kB)
Using cached sqlparse-0.5.3-py3-none-any.whl (44 kB)
Installing collected packages: sqlparse, asgiref, django
Successfully installed asgiref-3.9.1 django-4.2.24 sqlparse-0.5.3

[notice] A new release of pip is available: 25.0.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
nox > pytest -vv -n auto
==================================================================================================================================== test session starts =====================================================================================================================================
platform darwin -- Python 3.11.12, pytest-8.4.2, pluggy-1.6.0 -- /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5/.nox/test-3-11-django-4-2/bin/python3
cachedir: .pytest_cache
django: version: 4.2.24, settings: tests.settings (from ini)
rootdir: /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5
configfile: pyproject.toml
plugins: apiver-0.1.0, asyncio-1.2.0, xdist-3.8.0, django-4.11.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
8 workers [3 items]
scheduling tests via LoadScheduling

tests/unit/api/test_setup.py::test_apiver_exports[v1]
[gw1] [ 33%] PASSED tests/unit/api/test_setup.py::test_apiver_exports[v1]
tests/unit/internal/test_setup.py::test__setup
tests/unit/internal/test_django_setup.py::test__setup
[gw2] [ 66%] PASSED tests/unit/internal/test_setup.py::test__setup
[gw0] [100%] PASSED tests/unit/internal/test_django_setup.py::test__setup

====================================================================================================================================== warnings summary ======================================================================================================================================
.nox/test-3-11-django-4-2/lib/python3.11/site-packages/django/conf/__init__.py:241
.nox/test-3-11-django-4-2/lib/python3.11/site-packages/django/conf/__init__.py:241
.nox/test-3-11-django-4-2/lib/python3.11/site-packages/django/conf/__init__.py:241
.nox/test-3-11-django-4-2/lib/python3.11/site-packages/django/conf/__init__.py:241
.nox/test-3-11-django-4-2/lib/python3.11/site-packages/django/conf/__init__.py:241
.nox/test-3-11-django-4-2/lib/python3.11/site-packages/django/conf/__init__.py:241
.nox/test-3-11-django-4-2/lib/python3.11/site-packages/django/conf/__init__.py:241
.nox/test-3-11-django-4-2/lib/python3.11/site-packages/django/conf/__init__.py:241
.nox/test-3-11-django-4-2/lib/python3.11/site-packages/django/conf/__init__.py:241
  /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5/.nox/test-3-11-django-4-2/lib/python3.11/site-packages/django/conf/__init__.py:241: RemovedInDjango50Warning: The default value of USE_TZ will change from False to True in Django 5.0. Set USE_TZ to False in your project settings if you want to keep the current default behavior.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================================================== 3 passed, 9 warnings in 1.12s ================================================================================================================================
nox > Session test-3.11(django='4.2') was successful.
nox > Running session test-3.12(django='3.2')
nox > Creating virtual environment (venv) using python3.12 in .nox/test-3-12-django-3-2
nox > uv sync --active --no-editable --group test
Resolved 36 packages in 0.57ms
Installed 15 packages in 12ms
 + django-b54c8ff5==0.0.1.dev0+d20250916 (from file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5)
 + execnet==2.1.1
 + freezegun==1.5.5
 + iniconfig==2.1.0
 + packaging==25.0
 + pluggy==1.6.0
 + pygments==2.19.2
 + pytest==8.4.2
 + pytest-apiver==0.1.0
 + pytest-asyncio==1.2.0
 + pytest-django==4.11.1
 + pytest-xdist==3.8.0
 + python-dateutil==2.9.0.post0
 + six==1.17.0
 + typing-extensions==4.15.0
nox > pip install 'django~=3.2.0'
Collecting django~=3.2.0
  Using cached Django-3.2.25-py3-none-any.whl.metadata (4.1 kB)
Collecting asgiref<4,>=3.3.2 (from django~=3.2.0)
  Using cached asgiref-3.9.1-py3-none-any.whl.metadata (9.3 kB)
Collecting pytz (from django~=3.2.0)
  Using cached pytz-2025.2-py2.py3-none-any.whl.metadata (22 kB)
Collecting sqlparse>=0.2.2 (from django~=3.2.0)
  Using cached sqlparse-0.5.3-py3-none-any.whl.metadata (3.9 kB)
Using cached Django-3.2.25-py3-none-any.whl (7.9 MB)
Using cached asgiref-3.9.1-py3-none-any.whl (23 kB)
Using cached sqlparse-0.5.3-py3-none-any.whl (44 kB)
Using cached pytz-2025.2-py2.py3-none-any.whl (509 kB)
Installing collected packages: pytz, sqlparse, asgiref, django
Successfully installed asgiref-3.9.1 django-3.2.25 pytz-2025.2 sqlparse-0.5.3

[notice] A new release of pip is available: 25.0.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
nox > pytest -vv -n auto
==================================================================================================================================== test session starts =====================================================================================================================================
platform darwin -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5/.nox/test-3-12-django-3-2/bin/python3
cachedir: .pytest_cache
django: version: 3.2.25, settings: tests.settings (from ini)
rootdir: /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5
configfile: pyproject.toml
plugins: apiver-0.1.0, asyncio-1.2.0, xdist-3.8.0, django-4.11.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
8 workers [3 items]
scheduling tests via LoadScheduling

tests/unit/internal/test_django_setup.py::test__setup
tests/unit/internal/test_setup.py::test__setup
tests/unit/api/test_setup.py::test_apiver_exports[v1]
[gw1] [ 33%] PASSED tests/unit/api/test_setup.py::test_apiver_exports[v1]
[gw2] [ 66%] PASSED tests/unit/internal/test_setup.py::test__setup
[gw0] [100%] PASSED tests/unit/internal/test_django_setup.py::test__setup

====================================================================================================================================== warnings summary ======================================================================================================================================
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/http/request.py:1
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/http/request.py:1
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/http/request.py:1
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/http/request.py:1
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/http/request.py:1
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/http/request.py:1
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/http/request.py:1
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/http/request.py:1
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/http/request.py:1
  /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5/.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/utils/encoding.py:268
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/utils/encoding.py:268
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/utils/encoding.py:268
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/utils/encoding.py:268
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/utils/encoding.py:268
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/utils/encoding.py:268
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/utils/encoding.py:268
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/utils/encoding.py:268
.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/utils/encoding.py:268
  /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5/.nox/test-3-12-django-3-2/lib/python3.12/site-packages/django/utils/encoding.py:268: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================================================== 3 passed, 18 warnings in 1.20s ===============================================================================================================================
nox > Session test-3.12(django='3.2') was successful.
nox > Running session test-3.12(django='4.2')
nox > Creating virtual environment (venv) using python3.12 in .nox/test-3-12-django-4-2
nox > uv sync --active --no-editable --group test
Resolved 36 packages in 0.54ms
Installed 15 packages in 32ms
 + django-b54c8ff5==0.0.1.dev0+d20250916 (from file:///private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5)
 + execnet==2.1.1
 + freezegun==1.5.5
 + iniconfig==2.1.0
 + packaging==25.0
 + pluggy==1.6.0
 + pygments==2.19.2
 + pytest==8.4.2
 + pytest-apiver==0.1.0
 + pytest-asyncio==1.2.0
 + pytest-django==4.11.1
 + pytest-xdist==3.8.0
 + python-dateutil==2.9.0.post0
 + six==1.17.0
 + typing-extensions==4.15.0
nox > pip install 'django~=4.2.0'
Collecting django~=4.2.0
  Using cached django-4.2.24-py3-none-any.whl.metadata (4.2 kB)
Collecting asgiref<4,>=3.6.0 (from django~=4.2.0)
  Using cached asgiref-3.9.1-py3-none-any.whl.metadata (9.3 kB)
Collecting sqlparse>=0.3.1 (from django~=4.2.0)
  Using cached sqlparse-0.5.3-py3-none-any.whl.metadata (3.9 kB)
Using cached django-4.2.24-py3-none-any.whl (8.0 MB)
Using cached asgiref-3.9.1-py3-none-any.whl (23 kB)
Using cached sqlparse-0.5.3-py3-none-any.whl (44 kB)
Installing collected packages: sqlparse, asgiref, django
Successfully installed asgiref-3.9.1 django-4.2.24 sqlparse-0.5.3

[notice] A new release of pip is available: 25.0.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
nox > pytest -vv -n auto
==================================================================================================================================== test session starts =====================================================================================================================================
platform darwin -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5/.nox/test-3-12-django-4-2/bin/python3
cachedir: .pytest_cache
django: version: 4.2.24, settings: tests.settings (from ini)
rootdir: /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5
configfile: pyproject.toml
plugins: apiver-0.1.0, asyncio-1.2.0, xdist-3.8.0, django-4.11.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
8 workers [3 items]
scheduling tests via LoadScheduling

tests/unit/internal/test_setup.py::test__setup
tests/unit/internal/test_django_setup.py::test__setup
tests/unit/api/test_setup.py::test_apiver_exports[v1]
[gw1] [ 33%] PASSED tests/unit/api/test_setup.py::test_apiver_exports[v1]
[gw2] [ 66%] PASSED tests/unit/internal/test_setup.py::test__setup
[gw0] [100%] PASSED tests/unit/internal/test_django_setup.py::test__setup

====================================================================================================================================== warnings summary ======================================================================================================================================
.nox/test-3-12-django-4-2/lib/python3.12/site-packages/django/conf/__init__.py:241
.nox/test-3-12-django-4-2/lib/python3.12/site-packages/django/conf/__init__.py:241
.nox/test-3-12-django-4-2/lib/python3.12/site-packages/django/conf/__init__.py:241
.nox/test-3-12-django-4-2/lib/python3.12/site-packages/django/conf/__init__.py:241
.nox/test-3-12-django-4-2/lib/python3.12/site-packages/django/conf/__init__.py:241
.nox/test-3-12-django-4-2/lib/python3.12/site-packages/django/conf/__init__.py:241
.nox/test-3-12-django-4-2/lib/python3.12/site-packages/django/conf/__init__.py:241
.nox/test-3-12-django-4-2/lib/python3.12/site-packages/django/conf/__init__.py:241
.nox/test-3-12-django-4-2/lib/python3.12/site-packages/django/conf/__init__.py:241
  /private/var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1/django_b54c8ff5/.nox/test-3-12-django-4-2/lib/python3.12/site-packages/django/conf/__init__.py:241: RemovedInDjango50Warning: The default value of USE_TZ will change from False to True in Django 5.0. Set USE_TZ to False in your project settings if you want to keep the current default behavior.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================================================== 3 passed, 9 warnings in 1.26s ================================================================================================================================
nox > Session test-3.12(django='4.2') was successful.
nox > Ran multiple sessions:
nox > * test-3.11(django='3.2'): success
nox > * test-3.11(django='4.2'): success
nox > * test-3.12(django='3.2'): success
nox > * test-3.12(django='4.2'): success
nox > Session test_crufted_project(cruft_config_name='django') was successful.
nox > Running session cleanup_crufted_project
nox > Re-using existing virtual environment at .nox/cleanup_crufted_project.
nox > docker run --rm -v /var/folders/57/f1550bl16xj6cvrp68k0qx3m0000gn/T/rt_crufted_3x5rv4s1:/tmpdir/ alpine:3.18.0 rm -rf /tmpdir/default_4d2b959d /tmpdir/django_b54c8ff5
nox > Session cleanup_crufted_project was successful.
nox > Ran multiple sessions:
nox > * lint_crufted_project(cruft_config_name='default'): success
nox > * lint_crufted_project(cruft_config_name='django'): success
nox > * test_crufted_project(cruft_config_name='default'): success
nox > * test_crufted_project(cruft_config_name='django'): success
nox > * cleanup_crufted_project: success
```

</details>
